### PR TITLE
Rebuild/0.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,14 @@ requirements:
 test:
   requires:
     - pytest
-
+    - pip
+  imports:
+    - pyemd
   source_files:
     - test/
-
   commands:
     - pytest -v test/
+    - pip check
 
 about:
   home: https://github.com/wmayner/pyemd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,9 @@ requirements:
     - numpy   1.19  # [py<310]
     - numpy   1.21  # [py==310]
     - numpy   1.23  # [py>=311]
+    # see https://github.com/wmayner/pyemd/issues/59
+    - cython  0.29.33  # [py>=311]
+
 
   build:
     - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,15 +45,16 @@ test:
     - pytest -v test/
 
 about:
-  home: http://github.com/wmayner/pyemd
+  home: https://github.com/wmayner/pyemd
   license: MIT
   license_file: LICENSE
+  license_family: MIT
   summary: A Python wrapper for the Earth Mover's Distance.
   description: |
     PyEMD is a Python wrapper for Ofir Pele and Michael Werman’s implementation
     of the Earth Mover’s Distance that allows it to be used with NumPy.
-  doc_url: http://github.com/wmayner/pyemd
-  dev_url: http://github.com/wmayner/pyemd
+  doc_url: https://github.com/wmayner/pyemd
+  dev_url: https://github.com/wmayner/pyemd
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,14 @@ source:
 
 build:
   number: 1
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - python
     - setuptools
     - wheel
+    - pip
     - numpy   1.19  # [py<310]
     - numpy   1.21  # [py==310]
     - numpy   1.23  # [py>=311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,17 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   host:
     - python
     - setuptools
-    - numpy
+    - wheel
+    - numpy   1.19  # [py<310]
+    - numpy   1.21  # [py==310]
+    - numpy   1.23  # [py>=311]
 
   build:
     - {{ compiler('cxx') }}


### PR DESCRIPTION
# pyemd v0.5.1 b1

## Changes
- Bump build number
- Add strict host pinnings for numpy 
- Add a fix for python 3.11
- Add missing wheel and pip dependencies
- Use `pip install`